### PR TITLE
Fix for exploits by expiring block locations and also fixing memory leaks

### DIFF
--- a/src/me/phil14052/CustomCobbleGen/Events/BlockEvents.java
+++ b/src/me/phil14052/CustomCobbleGen/Events/BlockEvents.java
@@ -4,6 +4,7 @@
  */
 package me.phil14052.CustomCobbleGen.Events;
 
+import me.phil14052.CustomCobbleGen.Managers.GenBlock;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -25,7 +26,7 @@ public class BlockEvents implements Listener{
 	private TierManager tm = TierManager.getInstance();
 	private BlockManager bm = BlockManager.getInstance();
 	private CustomCobbleGen plugin = CustomCobbleGen.getInstance();
-	
+
 	@EventHandler
 	public void onBlockFlow(BlockFromToEvent e){
 		Block b = e.getBlock();
@@ -42,7 +43,12 @@ public class BlockEvents implements Listener{
 						//it is a Known gen location
 						if(!bm.getGenBreaks().containsKey(l)) return; //A player has not prev broken a block here
 						//A player has prev broken a block here
-						Player p = bm.getGenBreaks().get(l); //Get the player who broke the blocks tier
+						GenBlock gb = bm.getGenBreaks().get(l); //Get the GenBlock in this location
+						if (gb.hasExpired()) {
+							bm.removeKnownGenLocation(l);
+							return;
+						}
+						Player p = gb.getPlayer(); //Get the player who broke the blocks tier
 						Tier tier = tm.getSelectedTier(p); // ^
 
 						if(tier != null) {
@@ -74,7 +80,6 @@ public class BlockEvents implements Listener{
 		}
 	}
 	
-	
 	public boolean isWorldDisabled(World world) {
 		return plugin.getConfig().getList("options.disabled.worlds").contains(world.getName());
 	}
@@ -100,6 +105,4 @@ public class BlockEvents implements Listener{
 		
 		return false;
 	}
-	
-	
 }

--- a/src/me/phil14052/CustomCobbleGen/Events/PlayerEvents.java
+++ b/src/me/phil14052/CustomCobbleGen/Events/PlayerEvents.java
@@ -4,6 +4,7 @@
  */
 package me.phil14052.CustomCobbleGen.Events;
 
+import me.phil14052.CustomCobbleGen.Managers.BlockManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -19,6 +20,7 @@ import me.phil14052.CustomCobbleGen.Managers.TierManager;
 public class PlayerEvents implements Listener {
 
 	private TierManager tm = TierManager.getInstance();
+	private BlockManager bm = BlockManager.getInstance();
 
 	@EventHandler
 	public void onPlayerJoin(PlayerJoinEvent e){
@@ -32,6 +34,7 @@ public class PlayerEvents implements Listener {
 	public void onPlayerLeave(PlayerQuitEvent e) {
 		Player p = e.getPlayer();
 		tm.savePlayerData(p);
+		bm.cleanupExpiredLocations();
 	}
 	
 }

--- a/src/me/phil14052/CustomCobbleGen/Managers/BlockManager.java
+++ b/src/me/phil14052/CustomCobbleGen/Managers/BlockManager.java
@@ -16,13 +16,12 @@ public class BlockManager {
 
 	private static BlockManager instance = null;
 	private List<Location> knownGenLocations = new ArrayList<Location>();
-	private Map<Location, Player> genBreaks = new HashMap<Location, Player>();
-	
+	private Map<Location, GenBlock> genBreaks = new HashMap<Location, GenBlock>();
+
 	public static BlockManager getInstance() {
 		if(instance == null) instance = new BlockManager();
 		return instance;
 	}
-
 
 	public List<Location> getKnownGenLocations() {
 		return knownGenLocations;
@@ -39,6 +38,7 @@ public class BlockManager {
 	
 	public void removeKnownGenLocation(Location l) {
 		if(this.isGenLocationKnown(l)) this.getKnownGenLocations().remove(l);
+		if(this.genBreaks.containsKey(l)) this.genBreaks.remove(l);
 	}
 	
 	public void setKnownGenLocations(List<Location> knownGenLocations) {
@@ -48,16 +48,27 @@ public class BlockManager {
 	public void setPlayerForLocation(Player p, Location l) {
 		this.addKnownGenLocation(l);
 		if(this.getGenBreaks().containsKey(l)) this.getGenBreaks().remove(l);
-		this.getGenBreaks().put(l, p);
+
+		// Create a new GenBlock object to track the player+timestamp and add it to the genBreaks map
+		GenBlock gb = new GenBlock(l, p);
+		this.getGenBreaks().put(l, gb);
 	}
 	
-	public Map<Location, Player> getGenBreaks() {
+	public Map<Location, GenBlock> getGenBreaks() {
 		return genBreaks;
 	}
 
-
-	public void setGenBreaks(Map<Location, Player> genBreaks) {
+	public void setGenBreaks(Map<Location, GenBlock> genBreaks) {
 		this.genBreaks = genBreaks;
 	}
-	
+
+	public void cleanupExpiredLocations() {
+		// Remove all expired GenBlock entries
+		for (Map.Entry<Location, GenBlock> entry : genBreaks.entrySet()) {
+			GenBlock gb = entry.getValue();
+			if (gb.hasExpired()) {
+				removeKnownGenLocation(gb.getLocation());
+			}
+		}
+	}
 }

--- a/src/me/phil14052/CustomCobbleGen/Managers/GenBlock.java
+++ b/src/me/phil14052/CustomCobbleGen/Managers/GenBlock.java
@@ -1,0 +1,39 @@
+package me.phil14052.CustomCobbleGen.Managers;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import java.time.Instant;
+import java.time.Period;
+
+public class GenBlock {
+    private Location location;
+    private Player player;
+    private Instant timestamp;
+
+    public GenBlock(Location l, Player p) {
+        location = l;
+        player = p;
+        timestamp = Instant.now();
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public boolean hasExpired() {
+        // Expire entries 4 seconds after they were created
+        // It only needs enough time for lava/water to flow and generator a new block
+        if (Instant.now().getEpochSecond() >= (timestamp.getEpochSecond() + 4)) {
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Hi,
We've started using this plugin and I made some changes to it that you might be interested in. It shouldn't interfere with any normal operation, it fixes some exploits we noticed and some memory leaks:
- Made a new class called GenBlocks to track the timestamp of when
player breaks were tracked so they can be expired after 4 seconds (which
is just to allow enough time for lava/water to flow and create a new one)
- genBreaks entries were never being removed and keeping references to
Player objects, which can cause significant memory leaks.
- Players were able to use things like Slimefun miners to infinitely
obtain special ores just by mining once in another cobble gen and
letting an auto miner break the block.
- Also clears any expired GenBlocks whenever a player logs out.

I've tested this on our server and everything seems to operate as normal and also fixes the issues I mentioned above :)